### PR TITLE
apt: Use onion(balance) services for Debian repositories

### DIFF
--- a/config/includes.chroot/lib/live/config/9010-apttransport
+++ b/config/includes.chroot/lib/live/config/9010-apttransport
@@ -3,8 +3,13 @@
 Configure_apt_transport ()
 {
 
-        sed -i 's/http:/tor+https:/g' /etc/apt/sources.list.d/subgraph.list
-	sed -i 's/http:/tor+http:/g' /etc/apt/sources.list
+	sed -i 's,http:,tor+https:,g' /etc/apt/sources.list.d/subgraph.list
+
+	# vwakviie2ienjx6t.onion is the official onion service for ftp.d.o
+	# sgvtcaew4bxjd7ln.onion is the official onion service for ftp.d.o
+	# c.f. https://onion.debian.org/
+	sed -i 's,http://deb.debian.org,tor+http://vwakviie2ienjx6t.onion,g' /etc/apt/sources.list
+	sed -i 's,http://security.debian.org,tor+http://sgvtcaew4bxjd7ln.onion,g' /etc/apt/sources.list
 
 }
 

--- a/config/includes.installer/preseed.cfg
+++ b/config/includes.installer/preseed.cfg
@@ -317,7 +317,7 @@ d-i apt-setup/services-select multiselect
 # apt will complain about the unauthenticated repository and so the
 # sources.list line will be left commented out
 #d-i apt-setup/local0/key string http://local.server/key
-d-i apt-setup/local0/repository string deb http://httpredir.debian.org/debian stretch main contrib non-free
+d-i apt-setup/local0/repository string deb http://deb.debian.org/debian stretch main contrib non-free
 d-i apt-setup/local0/source boolean false
 d-i apt-setup/local0/key string file:///usr/share/keyrings/debian-archive-keyring.gpg
 d-i apt-setup/local1/repository string deb http://security.debian.org/debian-security stretch/updates main contrib non-free


### PR DESCRIPTION
- [x] Replace `httpredir.debian.org` with the CDN-backed `deb.debian.org` during initial install.
  `httpredir.d.o` is currently unmaintained and tends to have consistency issues. 
- [x] After install, use [the official onion services](http://5nca3wxl33tzlzj5.onion/) for Debian repositories.